### PR TITLE
Explain features necessary for the `pre_cache_static_routes` function.

### DIFF
--- a/packages/router/examples/static_generation.rs
+++ b/packages/router/examples/static_generation.rs
@@ -30,6 +30,8 @@ async fn main() {
             .join("\n")
     );
 
+    // This function is available if you enable the ssr feature
+    // on the dioxus_router crate.
     pre_cache_static_routes::<Route, _>(
         &mut renderer,
         &DefaultRenderer {


### PR DESCRIPTION
Hi folks! Thanks for all of your hard work on Dioxus. I got confused by something in the router's static generation docs and I thought a small explanatory comment could be helpful.